### PR TITLE
single pass implementation for DOGXL160 display on Raspberry Pi

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -67,6 +67,7 @@ SRC_COMMON_ALG= \
     csrc/u8g_pb16h2.c \
     csrc/u8g_pb16v1.c \
     csrc/u8g_pb16v2.c \
+    csrc/u8g_pb208v2.c \
     csrc/u8g_pb32h1.c \
     csrc/u8g_pb8h1.c \
     csrc/u8g_pb8h1f.c \

--- a/cppsrc/U8glib.h
+++ b/cppsrc/U8glib.h
@@ -771,6 +771,13 @@ class U8GLIB_DOGXL160_2X_GR : public U8GLIB
       { }
 };
 
+class U8GLIB_DOGXL160_RPI : public U8GLIB 
+{
+  public:
+    U8GLIB_DOGXL160_RPI(uint8_t cs, uint8_t a0, uint8_t reset = U8G_PIN_NONE) 
+      : U8GLIB(&u8g_dev_uc1610_dogxl160_rpi, cs, a0, reset)
+      { }
+};
 
 class U8GLIB_NHD27OLED_BW : public U8GLIB 
 {

--- a/csrc/u8g.h
+++ b/csrc/u8g.h
@@ -396,6 +396,8 @@ extern u8g_dev_t u8g_dev_uc1610_dogxl160_2x_bw_hw_spi;
 extern u8g_dev_t u8g_dev_uc1610_dogxl160_2x_gr_sw_spi;
 extern u8g_dev_t u8g_dev_uc1610_dogxl160_2x_gr_hw_spi;
 
+extern u8g_dev_t u8g_dev_uc1610_dogxl160_rpi;
+
 /* Display: Generic KS0108b, Size: 128x64 monochrom */
 extern u8g_dev_t u8g_dev_ks0108_128x64;         /* official Arduino Library interface */
 extern u8g_dev_t u8g_dev_ks0108_128x64_fast;    /* faster, but uses private tables from the Arduino Library */

--- a/csrc/u8g_dev_uc1610_dogxl160.c
+++ b/csrc/u8g_dev_uc1610_dogxl160.c
@@ -273,6 +273,42 @@ uint8_t u8g_dev_uc1610_dogxl160_2x_gr_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg
   return u8g_dev_pb16v2_base_fn(u8g, dev, msg, arg);
 }
 
+uint8_t u8g_dev_uc1610_dogxl160_rpi_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg)
+{
+  switch(msg)
+  {
+    case U8G_DEV_MSG_INIT:
+      u8g_InitCom(u8g, dev, U8G_SPI_CLK_CYCLE_300NS);
+      u8g_WriteEscSeqP(u8g, dev, u8g_dev_uc1610_dogxl160_init_seq);
+      break;
+    case U8G_DEV_MSG_STOP:
+      break;
+    case U8G_DEV_MSG_PAGE_NEXT:
+      {
+        u8g_pb_t *pb = (u8g_pb_t *)(dev->dev_mem);
+        
+        for (uint8_t j = 0; j < 26; j++) {
+            u8g_WriteEscSeqP(u8g, dev, u8g_dev_uc1610_dogxl160_data_start);    
+            u8g_WriteByte(u8g, dev, 0x060 | (pb->p.page*2+j) ); /* select current page (UC1610) */
+            u8g_SetAddress(u8g, dev, 1);           /* data mode */
+            if ( u8g_WriteSequence(u8g, dev, WIDTH, (uint8_t *)(pb->buf)+WIDTH*j) == 0 )
+              return 0;
+        }
+        
+        u8g_SetChipSelect(u8g, dev, 0);
+      }
+      break;
+    case U8G_DEV_MSG_CONTRAST:
+      u8g_SetChipSelect(u8g, dev, 1);
+      u8g_SetAddress(u8g, dev, 0);          /* instruction mode */
+      u8g_WriteByte(u8g, dev, 0x081);
+      u8g_WriteByte(u8g, dev, (*(uint8_t *)arg) >> 1);
+      u8g_SetChipSelect(u8g, dev, 0);      
+      return 1;
+  }
+  return u8g_dev_pb208v2_base_fn(u8g, dev, msg, arg);
+}
+
 U8G_PB_DEV(u8g_dev_uc1610_dogxl160_bw_sw_spi, WIDTH, HEIGHT, 8, u8g_dev_uc1610_dogxl160_bw_fn, U8G_COM_SW_SPI);
 U8G_PB_DEV(u8g_dev_uc1610_dogxl160_bw_hw_spi, WIDTH, HEIGHT, 8, u8g_dev_uc1610_dogxl160_bw_fn, U8G_COM_HW_SPI);
 
@@ -288,3 +324,7 @@ uint8_t u8g_dev_uc1610_dogxl160_2x_gr_buf[WIDTH*2] U8G_NOCOMMON ;
 u8g_pb_t u8g_dev_uc1610_dogxl160_2x_gr_pb = { {8, HEIGHT, 0, 0, 0},  WIDTH, u8g_dev_uc1610_dogxl160_2x_gr_buf}; 
 u8g_dev_t u8g_dev_uc1610_dogxl160_2x_gr_sw_spi = { u8g_dev_uc1610_dogxl160_2x_gr_fn, &u8g_dev_uc1610_dogxl160_2x_gr_pb, U8G_COM_SW_SPI };
 u8g_dev_t u8g_dev_uc1610_dogxl160_2x_gr_hw_spi = { u8g_dev_uc1610_dogxl160_2x_gr_fn, &u8g_dev_uc1610_dogxl160_2x_gr_pb, U8G_COM_HW_SPI };
+
+uint8_t u8g_dev_uc1610_dogxl160_rpi_buf[WIDTH*26] U8G_NOCOMMON ; 
+u8g_pb_t u8g_dev_uc1610_dogxl160_rpi_pb = { {HEIGHT, HEIGHT, 0, 0, 0},  WIDTH, u8g_dev_uc1610_dogxl160_rpi_buf}; 
+u8g_dev_t u8g_dev_uc1610_dogxl160_rpi = { u8g_dev_uc1610_dogxl160_rpi_fn, &u8g_dev_uc1610_dogxl160_rpi_pb, U8G_COM_HW_SPI };

--- a/csrc/u8g_pb208v2.c
+++ b/csrc/u8g_pb208v2.c
@@ -1,0 +1,176 @@
+/*
+
+  u8g_pb208v2.c
+  
+  208 bit height 2 bit per pixel page buffer
+  byte has vertical orientation
+
+  Universal 8bit Graphics Library
+  
+  Copyright (c) 2012, olikraus@gmail.com
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification, 
+  are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, this list 
+    of conditions and the following disclaimer.
+    
+  * Redistributions in binary form must reproduce the above copyright notice, this 
+    list of conditions and the following disclaimer in the documentation and/or other 
+    materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+  
+
+*/
+
+#include "u8g.h"
+#include <string.h>
+
+
+void u8g_pb208v2_Clear(u8g_pb_t *b)
+{
+  uint8_t *ptr = (uint8_t *)b->buf;
+  uint8_t *end_ptr = ptr;
+  
+  /* two bits per pixel, 16 bits height --> 8 pixel --> 4 pixel per byte */
+  
+  for (int i = 1; i <= 13; i++) { // TODO GK remove for
+    end_ptr += b->width;
+  }
+  
+  do
+  {
+    *ptr++ = 0;
+  } while( ptr != end_ptr );
+}
+
+void u8g_pb208v2Init(u8g_pb_t *b, void *buf, u8g_uint_t width)
+{
+  b->buf = buf;
+  b->width = width;
+  u8g_pb208v2_Clear(b);
+}
+
+void u8g_pb208v2_set_pixel(u8g_pb_t *b, u8g_uint_t x, u8g_uint_t y, uint8_t color_index)
+{
+  register uint8_t mask;
+  uint8_t *ptr = b->buf;
+  y -= b->p.page_y0;
+  if ( y >= 4 )
+  {
+    for (int i = 1; i <= y/4; i++) { // TODO GK remove for
+        ptr += b->width;
+    }
+  }
+  mask = 0x03;
+  y &= 0x03;
+  y <<= 1;
+  mask <<= y;
+  mask ^=0xff;
+  color_index &= 3;
+  color_index <<= y;
+  ptr += x;
+  *ptr &= mask;
+  *ptr |= color_index;
+}
+
+
+void u8g_pb208v2_SetPixel(u8g_pb_t *b, const u8g_dev_arg_pixel_t * const arg_pixel)
+{
+  if ( arg_pixel->y < b->p.page_y0 )
+    return;
+  if ( arg_pixel->y > b->p.page_y1 )
+    return;
+  if ( arg_pixel->x >= b->width )
+    return;
+  u8g_pb208v2_set_pixel(b, arg_pixel->x, arg_pixel->y, arg_pixel->color);
+}
+
+
+void u8g_pb208v2_Set8PixelStd(u8g_pb_t *b, u8g_dev_arg_pixel_t *arg_pixel)
+{
+  register uint8_t pixel = arg_pixel->pixel;
+  do
+  {
+    if ( pixel & 128 )
+    {
+      u8g_pb208v2_SetPixel(b, arg_pixel);
+    }
+    switch( arg_pixel->dir )
+    {
+      case 0: arg_pixel->x++; break;
+      case 1: arg_pixel->y++; break;
+      case 2: arg_pixel->x--; break;
+      case 3: arg_pixel->y--; break;
+    }
+    pixel <<= 1;
+  } while( pixel != 0  );
+}
+
+
+
+uint8_t u8g_dev_pb208v2_base_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg)
+{
+  u8g_pb_t *pb = (u8g_pb_t *)(dev->dev_mem);
+  switch(msg)
+  {
+    case U8G_DEV_MSG_SET_8PIXEL:
+      if ( u8g_pb_Is8PixelVisible(pb, (u8g_dev_arg_pixel_t *)arg) )
+      {
+        u8g_pb208v2_Set8PixelStd(pb, (u8g_dev_arg_pixel_t *)arg);
+      }
+      break;
+    case U8G_DEV_MSG_SET_PIXEL:
+      u8g_pb208v2_SetPixel(pb, (u8g_dev_arg_pixel_t *)arg);
+      break;
+    case U8G_DEV_MSG_INIT:
+      break;
+    case U8G_DEV_MSG_STOP:
+      break;
+    case U8G_DEV_MSG_PAGE_FIRST:
+      u8g_pb208v2_Clear(pb);
+      u8g_page_First(&(pb->p));
+      break;
+    case U8G_DEV_MSG_PAGE_NEXT:
+      if ( u8g_page_Next(&(pb->p)) == 0 )
+        return 0;
+      u8g_pb208v2_Clear(pb);
+      break;
+#ifdef U8G_DEV_MSG_IS_BBX_INTERSECTION
+    case U8G_DEV_MSG_IS_BBX_INTERSECTION:
+      return u8g_pb_IsIntersection(pb, (u8g_dev_arg_bbx_t *)arg);
+#endif
+    case U8G_DEV_MSG_GET_PAGE_BOX:
+      u8g_pb_GetPageBox(pb, (u8g_box_t *)arg);
+      break;
+    case U8G_DEV_MSG_GET_WIDTH:
+      *((u8g_uint_t *)arg) = pb->width;
+      break;
+    case U8G_DEV_MSG_GET_HEIGHT:
+      *((u8g_uint_t *)arg) = pb->p.total_height;
+      break;
+    case U8G_DEV_MSG_SET_COLOR_ENTRY:
+      break;
+    case U8G_DEV_MSG_SET_XY_CB:
+      break;
+    case U8G_DEV_MSG_GET_MODE:
+      return U8G_MODE_GRAY2BIT;
+  }
+  return 1;
+}
+ 
+  


### PR DESCRIPTION
Since Raspberry Pi has a lot of RAM, we are able to store all of the screen in memory (without multiple draw()s). This is implementation of such for DOGXL160 display using HW SPI on Raspberry Pi.

See also "gshegosh"'s comments at https://github.com/olikraus/u8glib/issues/171