### PR TITLE
Make U8glib a bit more universal

### DIFF
--- a/csrc/u8g.h
+++ b/csrc/u8g.h
@@ -898,6 +898,13 @@ defined(__18CXX) || defined(__PIC32MX)
 /*===============================================================*/
 /* com api */
 
+struct _u8g_com_t
+{
+  uint8_t clk_cycle_time;
+  uint8_t clk_mode;
+};
+typedef struct _u8g_com_t u8g_com_t;
+
 #define U8G_SPI_CLK_CYCLE_50NS 1
 #define U8G_SPI_CLK_CYCLE_100NS 2
 #define U8G_SPI_CLK_CYCLE_200NS 3
@@ -906,7 +913,15 @@ defined(__18CXX) || defined(__PIC32MX)
 #define U8G_SPI_CLK_CYCLE_1000NS 6
 #define U8G_SPI_CLK_CYCLE_NONE 255
 
+/* https://en.wikipedia.org/wiki/Serial_Peripheral_Interface_Bus#Clock_polarity_and_phase */
+#define U8G_SPI_MODE_0 0
+#define U8G_SPI_MODE_1 1
+#define U8G_SPI_MODE_2 2
+#define U8G_SPI_MODE_3 3
+#define U8G_SPI_MODE_NONE 255
+
 uint8_t u8g_InitCom(u8g_t *u8g, u8g_dev_t *dev, uint8_t clk_cycle_time);
+uint8_t u8g_InitExtCom(u8g_t *u8g, u8g_dev_t *dev, u8g_com_t *args);
 void u8g_StopCom(u8g_t *u8g, u8g_dev_t *dev);
 void u8g_EnableCom(u8g_t *u8g, u8g_dev_t *dev);         /* obsolete */
 void u8g_DisableCom(u8g_t *u8g, u8g_dev_t *dev);        /* obsolete */

--- a/csrc/u8g.h
+++ b/csrc/u8g.h
@@ -668,6 +668,9 @@ struct _u8g_dev_arg_irgb_t
 #define U8G_COM_MSG_WRITE_SEQ 6
 #define U8G_COM_MSG_WRITE_SEQ_P 7
 
+#define U8G_COM_MSG_ACQUIRE 8
+#define U8G_COM_MSG_RELEASE 9
+
 
 /* com driver */
 
@@ -911,6 +914,8 @@ void u8g_SetAddress(u8g_t *u8g, u8g_dev_t *dev, uint8_t address);
 uint8_t u8g_WriteByte(u8g_t *u8g, u8g_dev_t *dev, uint8_t val);
 uint8_t u8g_WriteSequence(u8g_t *u8g, u8g_dev_t *dev, uint8_t cnt, uint8_t *seq);
 uint8_t u8g_WriteSequenceP(u8g_t *u8g, u8g_dev_t *dev, uint8_t cnt, const uint8_t *seq);
+void u8g_AcquireCom(u8g_t *u8g, u8g_dev_t *dev);
+void u8g_ReleaseCom(u8g_t *u8g, u8g_dev_t *dev);
 
 
 

--- a/csrc/u8g.h
+++ b/csrc/u8g.h
@@ -899,8 +899,11 @@ defined(__18CXX) || defined(__PIC32MX)
 /* com api */
 
 #define U8G_SPI_CLK_CYCLE_50NS 1
-#define U8G_SPI_CLK_CYCLE_300NS 2
-#define U8G_SPI_CLK_CYCLE_400NS 3
+#define U8G_SPI_CLK_CYCLE_100NS 2
+#define U8G_SPI_CLK_CYCLE_200NS 3
+#define U8G_SPI_CLK_CYCLE_300NS 4
+#define U8G_SPI_CLK_CYCLE_400NS 5
+#define U8G_SPI_CLK_CYCLE_1000NS 6
 #define U8G_SPI_CLK_CYCLE_NONE 255
 
 uint8_t u8g_InitCom(u8g_t *u8g, u8g_dev_t *dev, uint8_t clk_cycle_time);

--- a/csrc/u8g_com_api.c
+++ b/csrc/u8g_com_api.c
@@ -83,6 +83,16 @@ uint8_t u8g_WriteSequenceP(u8g_t *u8g, u8g_dev_t *dev, uint8_t cnt, const uint8_
   return dev->com_fn(u8g, U8G_COM_MSG_WRITE_SEQ_P, cnt, (void *)seq);
 }
 
+void u8g_AcquireCom(u8g_t *u8g, u8g_dev_t *dev)
+{
+  dev->com_fn(u8g, U8G_COM_MSG_ACQUIRE, 0, NULL);
+}
+
+void u8g_ReleaseCom(u8g_t *u8g, u8g_dev_t *dev)
+{
+  dev->com_fn(u8g, U8G_COM_MSG_RELEASE, 0, NULL);
+}
+
 /*
   sequence := { direct_value | escape_sequence }
   direct_value := 0..254

--- a/csrc/u8g_com_api.c
+++ b/csrc/u8g_com_api.c
@@ -41,6 +41,12 @@ uint8_t u8g_InitCom(u8g_t *u8g, u8g_dev_t *dev, uint8_t clk_cycle_time)
   return dev->com_fn(u8g, U8G_COM_MSG_INIT, clk_cycle_time, NULL);
 }
 
+uint8_t u8g_InitExtCom(u8g_t *u8g, u8g_dev_t *dev, u8g_com_t *args)
+{
+  /* for compatibility, the clock cycle time is also the value of arg_val */
+  return dev->com_fn(u8g, U8G_COM_MSG_INIT, args->clk_cycle_time, args);
+}
+
 void u8g_StopCom(u8g_t *u8g, u8g_dev_t *dev)
 {
   dev->com_fn(u8g, U8G_COM_MSG_STOP, 0, NULL);


### PR DESCRIPTION
Hi,

This PR makes U8glib a bit more universal. I'm using this on an (ARM) IoT operating system ([RIOT-OS](https://github.com/RIOT-OS/RIOT/pull/5126)), together with a low-power SPI LCD that has different clock requirements.

* aaab641 &mdash; This commit adds support for extended initialization of the com level driver. It adds an extra structure/argument to specify the clock mode.
* a52e4eb &mdash; The list of SPI clock speeds is extended with this commit. I needed a 1MHz clock frequency.
* 83e7a5d &mdash; Locking of bus is added with this commit. The SPI or I2C bus can (potentially) be shared with other devices, or misused in concurrent applications. This commit adds two methods for acquiring/releasing a bus. It should be added before and after bus operations take place. I haven't modified the existing device drivers, but as long as the actual acquire/release call is not performed (in other words, the existing com drivers do not implement the messages), this should not have an impact on performance.

The commits above allow me to write a generic device driver that is still portable (in other words, not using methods that makes it dependent on the OS). I have tested this code only on an ARM platform. For an example device driver implementation, check [this gist](https://gist.github.com/basilfx/ac829a9fd583cbaf4a2f245c64b149e2).

Kind regards,
Bas
