### PR TITLE
Hardware SPI support for ATmega128

### DIFF
--- a/csrc/u8g_com_atmega_hw_spi.c
+++ b/csrc/u8g_com_atmega_hw_spi.c
@@ -149,7 +149,7 @@ uint8_t u8g_com_atmega_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void 
       else
       {
 #if defined (__AVR_ATmega128__)
-	PORTB &= ~_BV(1);
+        PORTB &= ~_BV(1);        /* SCK = 0 */
 #else
         PORTB &= ~_BV(5);        /* SCK = 0 */
 #endif

--- a/csrc/u8g_com_atmega_hw_spi.c
+++ b/csrc/u8g_com_atmega_hw_spi.c
@@ -96,6 +96,16 @@ uint8_t u8g_com_atmega_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void 
       u8g_SetPIOutput(u8g, U8G_PI_RESET);
       
       U8G_ATOMIC_START();
+
+#if defined (__AVR_ATmega128__)
+
+      DDRB |= _BV(2);          /* D0, MOSI */
+      DDRB |= _BV(1);          /* SCK */
+      DDRB |= _BV(0);           /* slave select */
+
+      PORTB &= ~_BV(2);        /* D0, MOSI = 0 */
+      PORTB &= ~_BV(1);        /* SCK = 0 */
+#else
       
       DDRB |= _BV(3);          /* D0, MOSI */
       DDRB |= _BV(5);          /* SCK */
@@ -103,6 +113,8 @@ uint8_t u8g_com_atmega_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void 
     
       PORTB &= ~_BV(3);        /* D0, MOSI = 0 */
       PORTB &= ~_BV(5);        /* SCK = 0 */
+
+#endif
       
       U8G_ATOMIC_END();
       
@@ -136,7 +148,11 @@ uint8_t u8g_com_atmega_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void 
       }
       else
       {
+#if defined (__AVR_ATmega128__)
+	PORTB &= ~_BV(1);
+#else
         PORTB &= ~_BV(5);        /* SCK = 0 */
+#endif
         /* enable */
         u8g_SetPILevel(u8g, U8G_PI_CS, 0); /* CS = 0 (low active) */
       }


### PR DESCRIPTION
I have updated the hardware SPI source file to work with the atmega128 controller which uses different pins for it's hardware SPI.