### PR TITLE
make pbm screen sizes less hardcoded

### DIFF
--- a/sys/pbm/dev/u8g_dev_pbm.c
+++ b/sys/pbm/dev/u8g_dev_pbm.c
@@ -9,6 +9,12 @@
 #include <stdio.h>
 #include "u8g.h"
 
+// These are default sizes. They can be changed without changing this
+// file by modifying the corresponding parts of the ug8_dev_t struct.
+// Changing the height and lowering the width is always possible. To
+// increase the width, the page buffer (u8g_pb_dev_pbm below) should
+// also be replaced by something bigger. The page height cannot be
+// changed.
 
 #if defined(U8G_16BIT)
 #define WIDTH 1024
@@ -33,6 +39,8 @@ uint8_t u8g_dev_pbm_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg)
 {
   static FILE *fp;
   u8g_pb_t *pb = (u8g_pb_t *)(dev->dev_mem);
+  u8g_uint_t width = ((u8g_pb_t*)dev->dev_mem)->width;
+  u8g_uint_t height = ((u8g_pb_t*)dev->dev_mem)->p.total_height;
   
   switch(msg)
   {
@@ -40,7 +48,7 @@ uint8_t u8g_dev_pbm_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg)
       u8g_pb_Clear(pb);
       u8g_page_First(&(pb->p));
       fp = fopen("u8g.pbm", "w");
-      fprintf(fp, "P4\n%d %d\n", WIDTH, HEIGHT);
+      fprintf(fp, "P4\n%d %d\n", width, height);
       return 1;
     case U8G_DEV_MSG_PAGE_NEXT:
       {
@@ -49,7 +57,7 @@ uint8_t u8g_dev_pbm_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg)
         for( j = 0; j < 8; j++ )
         {
           b = 0;
-          for( i = 0; i < WIDTH; i++ )
+          for( i = 0; i < width; i++ )
           {
             b<<= 1;
             if ( (((uint8_t *)(pb->buf))[i] & (1<<j)) != 0 )

--- a/sys/pbm/dev/u8g_dev_pbm_gr_h2.c
+++ b/sys/pbm/dev/u8g_dev_pbm_gr_h2.c
@@ -13,6 +13,12 @@
 #include "u8g.h"
 
 
+// These are default sizes. They can be changed without changing this
+// file by modifying the corresponding parts of the ug8_dev_t struct.
+// Changing the height and lowering the width is always possible. To
+// increase the width, the page buffer (u8g_pb_dev_pbm below) should
+// also be replaced by something bigger. The page height cannot be
+// changed.
 #define WIDTH 128
 #define HEIGHT 64
 #define PAGE_HEIGHT 4
@@ -42,6 +48,8 @@ uint8_t u8g_dev_pbm_8h2_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg)
 {
   static FILE *fp;
   u8g_pb_t *pb = (u8g_pb_t *)(dev->dev_mem);
+  u8g_uint_t width = ((u8g_pb_t*)dev->dev_mem)->width;
+  u8g_uint_t height = ((u8g_pb_t*)dev->dev_mem)->p.total_height;
   
   switch(msg)
   {
@@ -49,7 +57,7 @@ uint8_t u8g_dev_pbm_8h2_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg)
     case U8G_DEV_MSG_PAGE_FIRST:
 #ifdef __unix__      
       u8g_buf_lower_limit = u8g_pb_dev_pbm_buf;
-      u8g_buf_upper_limit = u8g_pb_dev_pbm_buf + WIDTH;
+      u8g_buf_upper_limit = u8g_pb_dev_pbm_buf + width;
 #endif
 
       u8g_pb_Clear(pb);
@@ -58,7 +66,7 @@ uint8_t u8g_dev_pbm_8h2_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg)
       if ( u8g_dev_pbm_h2_enable != 0 )
       {
 	fp = fopen("u8g.pbm", "w");
-	fprintf(fp, "P4\n%d %d\n", WIDTH, HEIGHT);
+	fprintf(fp, "P4\n%d %d\n", width, height);
       }
       return 1;
     case U8G_DEV_MSG_PAGE_NEXT:
@@ -74,7 +82,7 @@ uint8_t u8g_dev_pbm_8h2_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg)
 	  for(;;)
           {
 	    b1 = 0;
-	    b = ((uint8_t *)(pb->buf))[i+j*(WIDTH/4)];
+	    b = ((uint8_t *)(pb->buf))[i+j*(width/4)];
 	    for( k = 0; k < 4; k ++ )
 	    {
 	      b1 >>= 1;
@@ -84,7 +92,7 @@ uint8_t u8g_dev_pbm_8h2_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg)
 	    }
 	    i++;
 	    b2 = 0;
-	    b = ((uint8_t *)(pb->buf))[i+j*(WIDTH/4)];
+	    b = ((uint8_t *)(pb->buf))[i+j*(width/4)];
 	    for( k = 0; k < 4; k ++ )
 	    {
 	      b2 >>= 1;
@@ -94,7 +102,7 @@ uint8_t u8g_dev_pbm_8h2_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg)
 	    }
 	    i++;
 	    fprintf(fp, "%c", b1*16+b2);
-	    if ( i >= WIDTH/4 )
+	    if ( i >= width/4 )
 	      break;
 	  }
         }

--- a/sys/pbm/dev/u8g_dev_pbm_h.c
+++ b/sys/pbm/dev/u8g_dev_pbm_h.c
@@ -12,6 +12,12 @@
 #include "u8g.h"
 
 
+// These are default sizes. They can be changed without changing this
+// file by modifying the corresponding parts of the ug8_dev_t struct.
+// Changing the height and lowering the width is always possible. To
+// increase the width, the page buffer (u8g_pb_dev_pbm below) should
+// also be replaced by something bigger. The page height cannot be
+// changed.
 #define WIDTH 128
 #define HEIGHT 64
 #define PAGE_HEIGHT 8
@@ -41,6 +47,8 @@ uint8_t u8g_dev_pbm_8h1_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg)
 {
   static FILE *fp;
   u8g_pb_t *pb = (u8g_pb_t *)(dev->dev_mem);
+  u8g_uint_t width = ((u8g_pb_t*)dev->dev_mem)->width;
+  u8g_uint_t height = ((u8g_pb_t*)dev->dev_mem)->p.total_height;
   
   switch(msg)
   {
@@ -48,7 +56,7 @@ uint8_t u8g_dev_pbm_8h1_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg)
     case U8G_DEV_MSG_PAGE_FIRST:
 #ifdef __unix__      
       u8g_buf_lower_limit = u8g_pb_dev_pbm_buf;
-      u8g_buf_upper_limit = u8g_pb_dev_pbm_buf + WIDTH;
+      u8g_buf_upper_limit = u8g_pb_dev_pbm_buf + width;
 #endif
 
       u8g_pb_Clear(pb);
@@ -57,7 +65,7 @@ uint8_t u8g_dev_pbm_8h1_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg)
       if ( u8g_dev_pbm_h_enable != 0 )
       {
 	fp = fopen("u8g.pbm", "w");
-	fprintf(fp, "P4\n%d %d\n", WIDTH, HEIGHT);
+	fprintf(fp, "P4\n%d %d\n", width, height);
       }
       return 1;
     case U8G_DEV_MSG_PAGE_NEXT:
@@ -69,9 +77,9 @@ uint8_t u8g_dev_pbm_8h1_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg)
         for( j = 0; j < 8; j++ )
         {
           b = 0;
-          for( i = 0; i < WIDTH/8; i++ )
+          for( i = 0; i < width/8; i++ )
           {
-	    b = ((uint8_t *)(pb->buf))[i+j*(WIDTH/8)];
+	    b = ((uint8_t *)(pb->buf))[i+j*(width/8)];
 	    fprintf(fp, "%c", b);
 	  }
         }


### PR DESCRIPTION
The .c files for the pbm bitmap-writing virtual devices contain
constants for the output width and height. Previously these constants
were used throughout the code, making it impossible to change the width
and height without changing these constants.

With this change, only the initialization uses the constants, but the
rest of the code reads back the width and height from the device
struct and uses those. This enables a user of these devices to change
the width and height to change the size of the output.

This was tested for all three of the pbm devices.